### PR TITLE
Add a start-up delay

### DIFF
--- a/script.service.pip/pipservice.py
+++ b/script.service.pip/pipservice.py
@@ -153,6 +153,11 @@ if __name__ == '__main__':
 
     # start a xbmc monitor
     monitor = XbmcMonitor()
+    
+    # wait the delay time after startup
+    xbmc.log("[pip-service] Delay time before execution: %s seconds." % str(delay), xbmc.LOGDEBUG)
+    if monitor.waitForAbort(1 + delay):  # wait at least one second
+        return 0
 
     # init ffmpeg
     ffmpeg = Ffmpeg(imagefilename,

--- a/script.service.pip/pipservice.py
+++ b/script.service.pip/pipservice.py
@@ -132,6 +132,14 @@ if __name__ == '__main__':
     # get settings
     settings = pip.get_settings(__addon__)
 
+    # start a xbmc monitor
+    monitor = XbmcMonitor()
+
+    # wait the delay time after startup
+    delaytime = settings['delay']
+    xbmc.log("[pip-service] Delay time before execution: %s seconds." % str(delaytime), xbmc.LOGDEBUG)
+    monitor.waitForAbort(1 + delaytime)  # wait at least one second
+
     # init keymap
     keymap = Keymap(xbmcvfs.translatePath("special://home/userdata/keymaps/"))
     keymap.update(settings['keytoggle'], settings['keyback'], settings['keyup'], settings['keydown'])
@@ -150,14 +158,6 @@ if __name__ == '__main__':
 
     # get all available channel ids
     m3u.get_channel_ids()
-
-    # start a xbmc monitor
-    monitor = XbmcMonitor()
-    
-    # wait the delay time after startup
-    xbmc.log("[pip-service] Delay time before execution: %s seconds." % str(delay), xbmc.LOGDEBUG)
-    if monitor.waitForAbort(1 + delay):  # wait at least one second
-        return 0
 
     # init ffmpeg
     ffmpeg = Ffmpeg(imagefilename,

--- a/script.service.pip/resources/language/resource.language.de_de/strings.po
+++ b/script.service.pip/resources/language/resource.language.de_de/strings.po
@@ -96,7 +96,7 @@ msgctxt "#32050"
 msgid "Picture-in-Picture Service"
 msgstr "Bild-in-Bild Dienst"
 
-sgctxt "#32020"
+msgctxt "#32020"
 msgid "Key mapping"
 msgstr "Tastenzuordnung"
 

--- a/script.service.pip/resources/language/resource.language.de_de/strings.po
+++ b/script.service.pip/resources/language/resource.language.de_de/strings.po
@@ -96,7 +96,7 @@ msgctxt "#32050"
 msgid "Picture-in-Picture Service"
 msgstr "Bild-in-Bild Dienst"
 
-sgctxt "#32020"
+msgctxt "#32020"
 msgid "Key mapping"
 msgstr "Key Mapping"
 

--- a/script.service.pip/resources/language/resource.language.de_de/strings.po
+++ b/script.service.pip/resources/language/resource.language.de_de/strings.po
@@ -119,3 +119,11 @@ msgstr "Kanal hoch schalten"
 msgctxt "#32025"
 msgid "Channel down"
 msgstr "Kanal runter schalten"
+
+msgctxt "#32030"
+msgid "Other preferences"
+msgstr "Sonstige Einstellungen"
+
+msgctxt "#32031"
+msgid "Startup delay before action [seconds]"
+msgstr "Start-Verzögerung [Sekunden]"

--- a/script.service.pip/resources/language/resource.language.de_de/strings.po
+++ b/script.service.pip/resources/language/resource.language.de_de/strings.po
@@ -98,7 +98,7 @@ msgstr "Bild-in-Bild Dienst"
 
 sgctxt "#32020"
 msgid "Key mapping"
-msgstr "Key Mapping"
+msgstr "Tastenzuordnung"
 
 msgctxt "#32021"
 msgid "Usage: '[ctrl+][shift+]key (requires restart)'"
@@ -106,16 +106,16 @@ msgstr "Verwendung: '[ctrl+][shift+]key (benötigt Neustart)'"
 
 msgctxt "#32022"
 msgid "Enable/disable PIP"
-msgstr "Enable/disable PIP"
+msgstr "Aktiviere/Deaktiviere PIP PIP"
 
 msgctxt "#32023"
 msgid "Back to channel"
-msgstr "Zurück zum Kanal"
+msgstr "Zurück zum Sender"
 
 msgctxt "#32024"
 msgid "Channel up"
-msgstr "Kanal hoch schalten"
+msgstr "Nächster Sender"
 
 msgctxt "#32025"
 msgid "Channel down"
-msgstr "Kanal runter schalten"
+msgstr "Vorheriger Sender"

--- a/script.service.pip/resources/language/resource.language.en_gb/strings.po
+++ b/script.service.pip/resources/language/resource.language.en_gb/strings.po
@@ -119,3 +119,11 @@ msgstr ""
 msgctxt "#32025"
 msgid "Channel down"
 msgstr ""
+
+msgctxt "#32030"
+msgid "Other preferences"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Startup delay before action [seconds]"
+msgstr ""

--- a/script.service.pip/resources/lib/pip.py
+++ b/script.service.pip/resources/lib/pip.py
@@ -90,6 +90,7 @@ class Pip:
         self.settings['keyback'] = str(addon.getSetting('keyback'))
         self.settings['keyup'] = str(addon.getSetting('keyup'))
         self.settings['keydown'] = str(addon.getSetting('keydown'))
+        self.settings['delay'] = int(addon.getSetting('delay'))
 
         self.settingsValid = False
         if self.settings['tmpfolder'].replace(" ", "") == "":

--- a/script.service.pip/resources/settings.xml
+++ b/script.service.pip/resources/settings.xml
@@ -29,4 +29,7 @@
         <setting label="32024" type="text" id="keyup" default="ctrl+shift+up"/>
         <setting label="32025" type="text" id="keydown" default="ctrl+shift+down"/>
     </category>
+	<category label="32030">
+		<setting label="32031" type="slider" id="delay" default="5" range="0,5,60" option="int" enable="eq(-1,true)" />
+    </category>
 </settings>

--- a/script.service.pip/resources/settings.xml
+++ b/script.service.pip/resources/settings.xml
@@ -29,7 +29,7 @@
         <setting label="32024" type="text" id="keyup" default="ctrl+shift+up"/>
         <setting label="32025" type="text" id="keydown" default="ctrl+shift+down"/>
     </category>
-	<category label="32030">
-		<setting label="32031" type="slider" id="delay" default="5" range="0,5,60" option="int" enable="eq(-1,true)" />
+    <category label="32030">
+        <setting label="32031" type="slider" id="delay" default="5" range="0,5,60" option="int" enable="eq(-1,true)" />
     </category>
 </settings>

--- a/script.service.pip/resources/settings.xml
+++ b/script.service.pip/resources/settings.xml
@@ -30,6 +30,6 @@
         <setting label="32025" type="text" id="keydown" default="ctrl+shift+down"/>
     </category>
     <category label="32030">
-        <setting label="32031" type="slider" id="delay" default="5" range="0,5,60" option="int" enable="eq(-1,true)" />
+        <setting label="32031" type="slider" id="delay" default="5" range="0,5,60"/>
     </category>
 </settings>


### PR DESCRIPTION
If too many PVRs or other services are started with Kodi, it can happen that PiP starts before the actual PVR service, which leads to an error message. 
This PR adds an delay setting that circumvents this problem.