### PR TITLE
Add addon configuration setting for the thumbnail quality

### DIFF
--- a/script.service.pip/pipservice.py
+++ b/script.service.pip/pipservice.py
@@ -166,7 +166,8 @@ if __name__ == '__main__':
                     settings['password'],
                     settings['fps'],
                     settings['ffmpegopts'],
-                    settings['width'])
+                    settings['width'],
+                    settings['quality'])
 
     # test if ffmpeg executable is available
     if ffmpeg.test() and pip.get_settings_status():
@@ -206,7 +207,8 @@ if __name__ == '__main__':
                                         settings['password'],
                                         settings['fps'],
                                         settings['ffmpegopts'],
-                                        settings['width'])
+                                        settings['width'],
+                                        settings['quality'])
 
 
             if monitor.get_toggle_status():

--- a/script.service.pip/resources/language/resource.language.de_de/strings.po
+++ b/script.service.pip/resources/language/resource.language.de_de/strings.po
@@ -92,6 +92,10 @@ msgctxt "#32016"
 msgid "Additional command line options"
 msgstr "Zusätzliche Kommandozeilen-Optionen"
 
+msgctxt "#32017"
+msgid "Picture-in-Picture quality"
+msgstr "Bild-in-Bild Qualität"
+
 msgctxt "#32050"
 msgid "Picture-in-Picture Service"
 msgstr "Bild-in-Bild Dienst"

--- a/script.service.pip/resources/language/resource.language.en_gb/strings.po
+++ b/script.service.pip/resources/language/resource.language.en_gb/strings.po
@@ -92,6 +92,10 @@ msgctxt "#32016"
 msgid "Additional command line options"
 msgstr ""
 
+msgctxt "#32017"
+msgid "Picture-in-Picture quality"
+msgstr ""
+
 msgctxt "#32050"
 msgid "Picture-in-Picture service"
 msgstr ""

--- a/script.service.pip/resources/lib/ffmpeg.py
+++ b/script.service.pip/resources/lib/ffmpeg.py
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 import os
 import platform
 import subprocess
-
+import xbmc
 
 '''
 Class Ffmpeg
@@ -30,8 +30,8 @@ controls ffmpeg process
 class Ffmpeg:
 
     # constructor
-    def __init__(self, imagefilename, tmpfolder, username, password, fps, addoptions, width):
-        self.update_settings(tmpfolder, username, password, fps, addoptions, width)
+    def __init__(self, imagefilename, tmpfolder, username, password, fps, addoptions, width, quality):
+        self.update_settings(tmpfolder, username, password, fps, addoptions, width, quality)
         self.imagefile = tmpfolder + "/" + imagefilename
         self.proc = ""
         self.urlold = ""
@@ -43,13 +43,14 @@ class Ffmpeg:
 
 
     # update settings
-    def update_settings(self, tmpfolder, username, password, fps, addoptions, width):
+    def update_settings(self, tmpfolder, username, password, fps, addoptions, width, quality):
         self.tmpfolder = tmpfolder
         self.username = username
         self.password = password
         self.fps = fps
         self.addopts = addoptions
         self.width = width
+        self.quality = quality
 
 
     # test if ffmpeg is available
@@ -110,6 +111,8 @@ class Ffmpeg:
             self.stop()
 
             # create ffmpeg command to capture very second a new image from the IPTV url
+            quality = 31 - (3 * self.quality) // 10 # transform value given in percent to a range of 1..31 and reverse it - ffmpeg interprets smaller values as better quality
+            xbmc.log("[pip-service] Thumbnail quality: %d%% -> %d" % (self.quality, quality), xbmc.LOGDEBUG)
             cmd = ['ffmpeg',
                    '-nostdin',
                    '-i', urlauth,
@@ -117,7 +120,7 @@ class Ffmpeg:
                    '-ss', '00:00:08.000',
                    '-f', 'image2',
                    '-vf', 'fps=%d,scale=%d:-1' % (self.fps, self.width),
-                   '-qscale:v', '10',
+                   '-qscale:v', '%d' % (quality),
                    '-y',
                    '-update', 'true',
                    '-vcodec', 'mjpeg',

--- a/script.service.pip/resources/lib/pip.py
+++ b/script.service.pip/resources/lib/pip.py
@@ -79,6 +79,7 @@ class Pip:
         self.settings['width'] = int(addon.getSetting('width'))
         self.settings['height'] = int(addon.getSetting('height'))
         self.settings['fps'] = int(addon.getSetting('fps'))
+        self.settings['quality'] = int(addon.getSetting('quality'))
         self.settings['ipaddress'] = str(addon.getSetting('ipaddress'))
         self.settings['port'] = str(addon.getSetting('port'))
         self.settings['username'] = str(addon.getSetting('username'))

--- a/script.service.pip/resources/settings.xml
+++ b/script.service.pip/resources/settings.xml
@@ -4,11 +4,12 @@
     <category label="32000">
         <setting label="32001" type="bool" id="top" default="true"/>
         <setting label="32002" type="bool" id="left" default="true"/>
-        <setting label="32003" type="number" id="ygap" default="110"/>
-        <setting label="32004" type="number" id="xgap" default="10"/>
-        <setting label="32005" type="number" id="width" default="280"/>
-        <setting label="32006" type="number" id="height" default="160"/>
+        <setting label="32003" type="number" id="ygap" default="155"/>
+        <setting label="32004" type="number" id="xgap" default="5"/>
+        <setting label="32005" type="number" id="width" default="320"/>
+        <setting label="32006" type="number" id="height" default="180"/>
         <setting label="32012" type="slider" id="fps" default="10" range="1,25"/>
+        <setting label="32017" type="slider" id="quality" default="72" range="0,4,100" option="percent"/>
     </category>
     <category label="32007">
         <setting label="32008" type="ipaddress" id="ipaddress" default="127.0.0.1"/>

--- a/script.service.pip/resources/settings.xml
+++ b/script.service.pip/resources/settings.xml
@@ -4,10 +4,10 @@
     <category label="32000">
         <setting label="32001" type="bool" id="top" default="true"/>
         <setting label="32002" type="bool" id="left" default="true"/>
-        <setting label="32003" type="number" id="ygap" default="155"/>
-        <setting label="32004" type="number" id="xgap" default="5"/>
-        <setting label="32005" type="number" id="width" default="320"/>
-        <setting label="32006" type="number" id="height" default="180"/>
+        <setting label="32003" type="number" id="ygap" default="110"/>
+        <setting label="32004" type="number" id="xgap" default="10"/>
+        <setting label="32005" type="number" id="width" default="280"/>
+        <setting label="32006" type="number" id="height" default="160"/>
         <setting label="32012" type="slider" id="fps" default="10" range="1,25"/>
         <setting label="32017" type="slider" id="quality" default="72" range="0,4,100" option="percent"/>
     </category>


### PR DESCRIPTION
- the default value for the new setting corresponds to the original value of 10
- the used formula calculates output values ranging from 31 to 1 for input percentage values from 0 to 100
- since it seems impossible for any integer step value in the input range to achieve complete coverage of the output range, the following FFmpeg quality values cannot be set: 2, 8, 14, 20, and 26
- German translation provided
