### PR TITLE
Close active ffmpeg process when playback stops

### DIFF
--- a/script.service.pip/resources/lib/pip.py
+++ b/script.service.pip/resources/lib/pip.py
@@ -228,7 +228,7 @@ class Pip:
             self.winHdl.removeControl(self.lblNameHdl)
             del self.lblNameHdl
             self.img = False
-            
+
         # remove last image file if it exists
         if self.uuidfile != None:
             if os.path.exists(self.uuidfile):


### PR DESCRIPTION
This PR addresses the following misbehavior:
- start TV playback & activate PIP
- stop TV playback (e.g. by pressing "X" key) - the ffmpeg process continues to run
- start TV playback again - the PIP thumbnail is visible for the channel previously selected for it, although the PIP function hasn't been activated again